### PR TITLE
separate redis server

### DIFF
--- a/pkgs/immich-service.nix
+++ b/pkgs/immich-service.nix
@@ -89,9 +89,9 @@
           DB_USERNAME = cfg.dbUsername;
           DB_PASSWORD_FILE = cfg.dbPasswordFile;
           DB_PORT = toString cfg.dbPort;
-          REDIS_HOSTNAME = "redis";
+          REDIS_HOSTNAME = "redis.joukamachi.net";
+          REDIS_PORT = "6380";
         };
-        #dependsOn = [ "redis" ];
         autoStart = true;
         extraOptions = [ "--pod=immich" ];
       };
@@ -108,20 +108,15 @@
           DB_USERNAME = cfg.dbUsername;
           DB_PASSWORD_FILE = cfg.dbPasswordFile;
           DB_PORT = toString cfg.dbPort;
-          REDIS_HOSTNAME = "redis";
+          REDIS_HOSTNAME = "redis.joukamachi.net";
+          REDIS_PORT = "6380";
         };
-        #dependsOn = [ "redis" ];
         autoStart = true;
         extraOptions = [ "--pod=immich" ];
       };
       "immich-machine-learning" = {
         image = "ghcr.io/immich-app/immich-machine-learning:${immichVersion}";
         volumes = [ "model-cache:/usr/src/app/upload" ];
-        autoStart = true;
-        extraOptions = [ "--pod=immich" ];
-      };
-      "redis" = {
-        image = "redis:6.2-alpine@sha256:70a7a5b641117670beae0d80658430853896b5ef269ccf00d1827427e3263fa3";
         autoStart = true;
         extraOptions = [ "--pod=immich" ];
       };
@@ -137,7 +132,6 @@
         "podman-immich-server.service" 
         "podman-immich-microservices.service" 
         "podman-immich-machinelearning.service" 
-        "podman-redis.service" 
       ];
 
       script = ''

--- a/pumpkin-configuration.nix
+++ b/pumpkin-configuration.nix
@@ -9,6 +9,7 @@
 
       # services to put here
       ./services/dns.nix
+      ./services/redis.nix
     ];
 
   hardware.enableRedistributableFirmware = true;

--- a/services/dns.nix
+++ b/services/dns.nix
@@ -23,6 +23,8 @@ let domain = "joukamachi.net";
       "taskserver" = hosts.kura;
       "ttw.music" = hosts.kura;
 
+      "redis" = hosts.pumpkin;
+
       "ns" = hosts.apple;
       "ns1" = hosts.apple;
       "ns2" = hosts.pumpkin;

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -8,6 +8,9 @@ let
       enable = true;
       openFirewall = true;
       bind = null;
+      settings = {
+        protected-mode = "no";
+      };
     };
   };
   servers = [

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -19,6 +19,7 @@ let
   ];
 in
 {
+  services.redis.vmOverCommit = true;
   services.redis.servers = builtins.listToAttrs (map redisConfig servers);
 
   services.telegraf = {

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -1,24 +1,17 @@
 { config, services, pkgs, ... }:
 
+let servers = [
+  { name = "scratch"; port = 6379; }
+  { name = "immich"; port = 6380; }
+];
+in
 {
-  services.redis.servers = {
-    "scratch" = {
-      enable = true;
-      port = 6379;
-    };
-    "immich" = {
-      enable = true;
-      port = 6380;
-    };
-  };
+  services.redis.servers = builtins.listToAttrs (map (s: { name = s.name; value = { port = s.port; enable = true; openFirewall = true; };}) servers);
 
   services.telegraf = {
     extraConfig = {
       inputs = {
-        servers = [ 
-          "tcp://redis.joukamachi.net:6379"
-          "tcp://redis.joukamachi.net:6380"
-        ];
+        servers = map (s: "tcp://redis.joukamachi.net:" + toString s.port) servers;
       };
     };
   };

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -11,5 +11,16 @@
       port = 6380;
     };
   };
+
+  services.telegraf = {
+    extraConfig = {
+      inputs = {
+        servers = [ 
+          "tcp://redis.joukamachi.net:6379"
+          "tcp://redis.joukamachi.net:6380"
+        ];
+      };
+    };
+  };
 }
 

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -1,0 +1,15 @@
+{ config, services, pkgs, ... }:
+
+{
+  services.redis.servers = {
+    "scratch" = {
+      enable = true;
+      port = 6379;
+    };
+    "immich" = {
+      enable = true;
+      port = 6380;
+    };
+  };
+}
+

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -1,12 +1,22 @@
 { config, services, pkgs, ... }:
 
-let servers = [
-  { name = "scratch"; port = 6379; }
-  { name = "immich"; port = 6380; }
-];
+let 
+  redisConfig = s: {
+    name = s.name;
+    value = {
+      port = s.port;
+      enable = true;
+      openFirewall = true;
+      bind = null;
+    };
+  };
+  servers = [
+    { name = "scratch"; port = 6379; }
+    { name = "immich"; port = 6380; }
+  ];
 in
 {
-  services.redis.servers = builtins.listToAttrs (map (s: { name = s.name; value = { port = s.port; enable = true; openFirewall = true; };}) servers);
+  services.redis.servers = builtins.listToAttrs (map redisConfig servers);
 
   services.telegraf = {
     extraConfig = {


### PR DESCRIPTION
- redis: basic scratch server and one for immich
- redis: redis hosted on pumpkin
- immich: switch from separate immich redis instance to global one
- redis: add telegraf monitoring
- redis: make it easier to extend config
- redis: move server config to top-level function so it's easier to edit
- redis: don't use protected mode for now
- redis: enable overcommit
